### PR TITLE
TT2-929: Add Retain policy to buckets

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.4.11",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"

--- a/template.yaml
+++ b/template.yaml
@@ -105,6 +105,8 @@ Resources:
       - AuditFileReadyToEncryptQueuePolicy
       - AuditMessageFailedProcessingQueuePolicy
     Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       BucketName: !Sub ${AWS::StackName}-${Environment}-message-batch
       BucketEncryption:
@@ -273,6 +275,8 @@ Resources:
 
   PermanentMessageBatchBucket:
     Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       BucketName: !Sub ${AWS::StackName}-${Environment}-permanent-message-batch
       BucketEncryption:


### PR DESCRIPTION
[TT2-929](https://govukverify.atlassian.net/browse/TT2-929)

**Testing**
Once the audit stack with the changes got deployed, deleted the stack TT2-929 stack manually.
Once the stack was deleted, the corresponding empty S3 MessageBucket and PermanentMessageBucket could still be seen, as expected

<img width="691" alt="Screenshot 2023-10-11 at 14 44 32" src="https://github.com/govuk-one-login/txma-audit/assets/26764987/805ad110-b080-44f2-8641-dbe523129084">

<img width="1038" alt="Screenshot 2023-10-11 at 14 44 17" src="https://github.com/govuk-one-login/txma-audit/assets/26764987/ff722070-7a9a-4521-a29f-e4d106cd9456">



[TT2-929]: https://govukverify.atlassian.net/browse/TT2-929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ