### PR TITLE
DPT-936: add txma top level field to athena

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -727,6 +727,8 @@ Resources:
               Type: string
             - Name: extensions
               Type: string
+            - Name: txma
+              Type: string
           Compressed: true
           InputFormat: org.apache.hadoop.mapred.TextInputFormat
           Location: !Sub s3://${MessageBatchBucket}/firehose/


### PR DESCRIPTION
- https://govukverify.atlassian.net/browse/DPT-936
- https://govukverify.atlassian.net/browse/DPT-928

To help with https://govukverify.atlassian.net/browse/DPT-928, https://govukverify.atlassian.net/browse/DPT-936 allows the audit store to search through top level `txma` field in the audit events. 

This does not apply to the SAL tables