### PR TITLE
Bau bot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,8 +3,12 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: daily
-      time: '03:00'
+      interval: weekly
+    groups:
+      dev-deps:
+        dependency-type: development
+      prod-deps:
+        dependency-type: production
     target-branch: main
     labels:
       - dependabot
@@ -18,8 +22,11 @@ updates:
   - package-ecosystem: 'docker'
     directory: '/tests'
     schedule:
-      interval: daily
-      time: '03:00'
+      interval: weekly
+    groups:
+      dev-deps:
+        patterns:
+          - '*'
     target-branch: main
     labels:
       - dependabot
@@ -30,7 +37,11 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: daily
+      interval: weekly
+    groups:
+      actions-deps:
+        patterns:
+          - '*'
     target-branch: main
     labels:
       - dependabot

--- a/.github/workflows/build-test-package.yaml
+++ b/.github/workflows/build-test-package.yaml
@@ -22,6 +22,7 @@ jobs:
           node-version: 22
           cache: npm
       - name: Install node packages
+        id: npm_install
         run: npm ci
       - name: Setup Python 3.8
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -35,10 +36,10 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets.GH_ACTIONS_VALIDATE_ROLE_ARN }}
       - name: Run linting
-        if: always()
+        if: ${{ steps.npm_install.outcome == 'success' }}
         run: npm run lint
       - name: Run tests
-        if: always()
+        if: ${{ steps.npm_install.outcome == 'success' }}
         run: npm run test
       - name: Validate SAM template
         if: always()

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "jest",
     "test:cov": "jest --coverage",
     "test:integration": "jest -c ./tests/integration-tests/jest.config.integration.ts",
-    "updateGitHubActions": "updateGitHubActions.sh",
+    "updateGitHubActions": "./updateGitHubActions.sh",
     "tsFile": "ts-node"
   },
   "dependencies": {


### PR DESCRIPTION
BAU but related to https://govukverify.atlassian.net/browse/DPT-1645

## :bulb: Description

Reduce dependabot spam

## :sparkles: Changes Made

Update dependabot config to group types of updates and only run weekly
Fix in package.json for running the github actions update script
Changed the build action to not run linting and test steps if the npm install fails. Only really an issue when dependabot updates don't work

