### PR TITLE
DPT-2138 Add Aws log filters

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1276,7 +1276,7 @@ Resources:
     Condition: IsProductionOrStaging
     Properties:
       LogGroupName: !Ref AuditMessageDeliveryStreamLogs
-      FilterPattern: ''
+      FilterPattern: '{ $.level = * && $.level != %TRACE|DEBUG% }'
       DestinationArn: '{{resolve:ssm:CSLSLogsDestination}}'
 
   CslsAuditMessageDelimiterFunctionSubscription:
@@ -1284,7 +1284,7 @@ Resources:
     Condition: IsProductionOrStaging
     Properties:
       LogGroupName: !Ref AuditMessageDelimiterLogs
-      FilterPattern: ''
+      FilterPattern: '{ $.level = * && $.level != %TRACE|DEBUG% }'
       DestinationArn: '{{resolve:ssm:CSLSLogsDestination}}'
 
   CslsAuditMessageFirehoseReingestLogsSubscription:
@@ -1292,7 +1292,7 @@ Resources:
     Condition: IsProductionOrStaging
     Properties:
       LogGroupName: !Ref AuditMessageFirehoseReingestLogs
-      FilterPattern: ''
+      FilterPattern: '{ $.level = * && $.level != %TRACE|DEBUG% }'
       DestinationArn: '{{resolve:ssm:CSLSLogsDestination}}'
 
   CslsS3CopyAndEncryptLogsSubscription:
@@ -1300,7 +1300,7 @@ Resources:
     Condition: IsProductionOrStaging
     Properties:
       LogGroupName: !Ref S3CopyAndEncryptLogs
-      FilterPattern: ''
+      FilterPattern: '{ $.level = * && $.level != %TRACE|DEBUG% }'
       DestinationArn: '{{resolve:ssm:CSLSLogsDestination}}'
 
   ###########################


### PR DESCRIPTION
- **Ticket Number**: :ticket:: https://govukverify.atlassian.net/browse/DPT-2138

## :bulb: Description

Add filters to AWS CloudWatch subscriptions to stop AWS Lambda system logs and messages with level "Debug", & "Trace" from being forwarded on to Splunk.


## :test_tube: Testing Instructions/Notes

Check the logs in CloudWatch And compare in Splunk. Lambda System logs (START, END, REPORT messages) should not be visible in splunk. We don't currently have any messages at Debug or Trace level.
