### PR TITLE
Dpt 2262 - add meta data to audit auto tests

### DIFF
--- a/tests/constants/baseEvent.ts
+++ b/tests/constants/baseEvent.ts
@@ -1,5 +1,31 @@
 import { AuditEvent } from '../support/types/auditEvent'
 
+export const txmaMetaDataEnrichmentSuccessful = {
+  txma: {
+    enrichment: [
+      {
+        count: 0,
+        event_id: 'a9e6cf46-eb1c-48d7-b9e8-3ac3f5f854b7',
+        service: 'client_id_enrichment'
+      }
+    ],
+    obfuscated: true
+  }
+}
+
+export const txmaMetaDataEnrichmentUnsuccessful = {
+  txma: {
+    enrichment: [
+      {
+        count: 5,
+        service: 'client_id_enrichment',
+        status: 'failed'
+      }
+    ],
+    obfuscated: true
+  }
+}
+
 export const baseEvent: AuditEvent = {
   event_name: 'AUTH_IPV_CAPACITY_REQUESTED',
   component_id: 'AuthAccountMgmt',

--- a/tests/e2eTests/testSuites/eventProcessedByFirehoseAuditE2e.spec.ts
+++ b/tests/e2eTests/testSuites/eventProcessedByFirehoseAuditE2e.spec.ts
@@ -1,7 +1,10 @@
 import { invokeLambdaFunction } from '../../support/utils/aws/lambda/invokeLambda'
 import { getEnv } from '../../../common/utils/helpers/getEnv'
 import { randomUUID } from 'crypto'
-import { baseEvent } from '../../constants/baseEvent'
+import {
+  baseEvent,
+  txmaMetaDataEnrichmentSuccessful
+} from '../../constants/baseEvent'
 import { getAuditEvent } from '../../support/utils/aws/s3/getAuditEvent'
 
 describe('events processed by firehose e2e', () => {
@@ -15,6 +18,7 @@ describe('events processed by firehose e2e', () => {
 
     event = {
       ...baseEvent,
+      ...txmaMetaDataEnrichmentSuccessful,
       event_id: eventId,
       timestamp_ms: timestampMs,
       timestamp_ms_formatted: timestampMsFormatted

--- a/tests/integrationTests/testSuites/eventProcessedByFirehoseAudit.spec.ts
+++ b/tests/integrationTests/testSuites/eventProcessedByFirehoseAudit.spec.ts
@@ -1,37 +1,67 @@
 import { invokeLambdaFunction } from '../../support/utils/aws/lambda/invokeLambda'
 import { getEnv } from '../../../common/utils/helpers/getEnv'
 import { randomUUID } from 'crypto'
-import { baseEvent } from '../../constants/baseEvent'
+import {
+  baseEvent,
+  txmaMetaDataEnrichmentSuccessful,
+  txmaMetaDataEnrichmentUnsuccessful
+} from '../../constants/baseEvent'
 import { getAuditEvent } from '../../support/utils/aws/s3/getAuditEvent'
 
 describe('events processed by firehose', () => {
-  let eventId: string
+  let eventId1: string
+  let eventId2: string
   const timestampMs = 1689936499616
   const timestampMsFormatted = '2023-07-21T10:48:19.616Z'
-  let event: unknown
+  let event1: unknown
+  let event2: unknown
 
   beforeAll(async () => {
-    eventId = randomUUID()
+    eventId1 = randomUUID()
+    eventId2 = randomUUID()
 
-    event = {
+    event1 = {
       ...baseEvent,
-      event_id: eventId,
+      ...txmaMetaDataEnrichmentSuccessful,
+      event_id: eventId1,
       timestamp_ms: timestampMs,
       timestamp_ms_formatted: timestampMsFormatted
     }
 
     await invokeLambdaFunction(getEnv('FIREHOSE_DELIVERY_STREAM_NAME'), {
-      data: event,
+      data: event1,
       firehose: getEnv('FIREHOSE_AUDIT_MESSAGE_BATCH_NAME')
     })
-    console.log(`Event ID for ${baseEvent.event_name}: ${eventId}`)
+    console.log(`Event ID for ${baseEvent.event_name}: ${eventId1}`)
+
+    event2 = {
+      ...baseEvent,
+      ...txmaMetaDataEnrichmentUnsuccessful,
+      event_id: eventId2,
+      timestamp_ms: timestampMs,
+      timestamp_ms_formatted: timestampMsFormatted
+    }
+
+    await invokeLambdaFunction(getEnv('FIREHOSE_DELIVERY_STREAM_NAME'), {
+      data: event2,
+      firehose: getEnv('FIREHOSE_AUDIT_MESSAGE_BATCH_NAME')
+    })
+    console.log(`Event ID for ${baseEvent.event_name}: ${eventId2}`)
   })
 
-  test('Audit event successfully processed and found in Temp Audit S3 Bucket', async () => {
+  test('Audit event with successful enrichment txma meta data successfully processed and found in Temp Audit S3 Bucket', async () => {
     const eventBodyFromFraudBucket = await getAuditEvent(
       getEnv('AUDIT_BUILD_MESSAGE_BATCH_NAME'),
-      eventId
+      eventId1
     )
-    expect(eventBodyFromFraudBucket).toEqual(event)
+    expect(eventBodyFromFraudBucket).toEqual(event1)
+  })
+
+  test('Audit event with failed enrichment txma meta data successfully processed and found in Temp Audit S3 Bucket', async () => {
+    const eventBodyFromFraudBucket = await getAuditEvent(
+      getEnv('AUDIT_BUILD_MESSAGE_BATCH_NAME'),
+      eventId2
+    )
+    expect(eventBodyFromFraudBucket).toEqual(event2)
   })
 })


### PR DESCRIPTION
- **Ticket Number**: :ticket:: https://govukverify.atlassian.net/browse/DPT-2262

## :bulb: Description

Add txma meta data for successful/unsuccessful enrichment to audit tests in build and staging

## :test_tube: Testing Instructions/Notes
Run npm run test:integration in the audit-build account
Run npm run test:e2e in the audit staging account

## :framed_picture: Screenshots (if applicable)
<img width="728" height="247" alt="image" src="https://github.com/user-attachments/assets/bb6eb962-05ff-468f-a77f-45bda9bd947e" />

<img width="724" height="214" alt="image" src="https://github.com/user-attachments/assets/ddb6b68f-7ea4-4da4-901b-0b5dc4431e36" />

We can see the meta data value being stored in the audit store in staging
<img width="1498" height="145" alt="image" src="https://github.com/user-attachments/assets/17795b6b-3699-46b7-8a8e-a24983af80a1" />